### PR TITLE
[Hotfix] On drop doesn't work after firefox update

### DIFF
--- a/src/components/LayoutComposer/Index.vue
+++ b/src/components/LayoutComposer/Index.vue
@@ -112,6 +112,10 @@ export default {
       if (!this.internalEditable) return true
     })
 
+    document.addEventListener('drop', event => {
+      event.preventDefault()
+    })
+
     EventBus.$on('global:dragend', () => {
       if (!this.internalEditable) return false
       setTimeout(() => {


### PR DESCRIPTION
Fix for issue #2 